### PR TITLE
implemented root finding

### DIFF
--- a/python/findroots.ipynb
+++ b/python/findroots.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os,sys\n",
+    "sys.path.insert(0, os.path.abspath(os.getcwd() + \"/../build/python/\"))\n",
+    "import pyqedfv as qedfv\n",
+    "import numpy as np\n",
+    "from scipy.optimize import brentq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from spherical to Cartesian coordinates\n",
+    "def toCartesian(v):\n",
+    "    x = v[0] * np.sin(v[1]) * np.cos(v[2])\n",
+    "    y = v[0] * np.sin(v[1]) * np.sin(v[2])\n",
+    "    z = v[0] * np.cos(v[1])\n",
+    "    return np.array([x, y, z])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# inputs\n",
+    "vnorm = 0.99\n",
+    "j = 0.\n",
+    "qedr = True\n",
+    "\n",
+    "# defining qedl and qedr\n",
+    "cqedl = qedfv.Coef()\n",
+    "cqedr = qedfv.Coef(qed=qedfv.Qed.r)\n",
+    "\n",
+    "pv = np.array([vnorm, 0.0, 0.0])\n",
+    "\n",
+    "if qedr == True:\n",
+    "    par = cqedr.tune(j, pv)\n",
+    "    f = lambda th, phi: cqedr(j, toCartesian([vnorm, th, phi]), par)\n",
+    "    filename = \"../tests/roots_c%d_v%s_qedr.txt\" % (int(j), vnorm)\n",
+    "else:\n",
+    "    par = cqedl.tune(j, pv)\n",
+    "    f = lambda th, phi: cqedl(j, toCartesian([vnorm, th, phi]), par)\n",
+    "    filename = \"../tests/roots_c%d_v%s_qedl.txt\" % (int(j), vnorm)\n",
+    "\n",
+    "# finding roots\n",
+    "results = []\n",
+    "\n",
+    "for phi in np.arange(0, np.pi / 4.0, 0.015):\n",
+    "    sphi = np.sin(phi)\n",
+    "    thMin = -2.0 * np.arctan(sphi - np.sqrt(1.0 + sphi ** 2.0))\n",
+    "    thMax = np.pi / 2.0\n",
+    "    thHalf = thMin + 0.5 * (thMax - thMin)\n",
+    "\n",
+    "    if f(thMin, phi) * f(thHalf, phi) < 0:\n",
+    "        try:\n",
+    "            th = brentq(f, thMin, thHalf, args=(phi,))\n",
+    "            results.append([th, phi, f(th, phi)])\n",
+    "        except ValueError as e:\n",
+    "            print(\"Error:\", e)\n",
+    "    \n",
+    "    if f(thHalf, phi) * f(thMax, phi) < 0:\n",
+    "        try:\n",
+    "            th = brentq(f, thHalf, thMax, args=(phi,))\n",
+    "            results.append([th, phi, f(th, phi)])\n",
+    "        except ValueError as e:\n",
+    "            print(\"Error:\", e)\n",
+    "\n",
+    "# print on file\n",
+    "np.savetxt(filename, results, fmt='%.18e')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook finds the roots of a finite-volume coefficients, given the magnitude of the velocity `vnorm`, the index `j` and the qed regularisation.

For each value of `phi`, the root-finding is performed on two separate ranges of `th`: `(thMin, thHalf)` and `(thHalf, thMax)`. This is done because, in many cases, at fixed `phi` there might be multiple roots and a scan in `(thMin, thMax)` would only detect one.