### PR TITLE
implementation of c3 and c3vl

### DIFF
--- a/lib/qedfv/coef.cpp
+++ b/lib/qedfv/coef.cpp
@@ -26,6 +26,14 @@ using namespace qedfv;
 
 const std::map<std::string, Coef::Qed> Coef::qedMap = {{"L", Qed::L}, {"r", Qed::r}};
 
+gsl_integration_workspace *Coef::intWorkspace_r_ =
+    gsl_integration_workspace_alloc(QEDFV_GSL_INT_LIMIT);
+gsl_integration_workspace *Coef::intWorkspace_th_ =
+    gsl_integration_workspace_alloc(QEDFV_GSL_INT_LIMIT);
+gsl_integration_workspace *Coef::intWorkspace_ph_ =
+    gsl_integration_workspace_alloc(QEDFV_GSL_INT_LIMIT);
+gsl_function Coef::gsl_f_r, Coef::gsl_f_th, Coef::gsl_f_ph;
+
 // Public interface ////////////////////////////////////////////////////////////////////////////////
 Coef::Coef(const Coef::Qed qed, const bool debug)
 {
@@ -33,9 +41,18 @@ Coef::Coef(const Coef::Qed qed, const bool debug)
   setQed(qed);
   jCache_ = std::nan("");
   intWorkspace_ = gsl_integration_workspace_alloc(QEDFV_GSL_INT_LIMIT);
+  intWorkspace_r_ = gsl_integration_workspace_alloc(QEDFV_GSL_INT_LIMIT);
+  intWorkspace_th_ = gsl_integration_workspace_alloc(QEDFV_GSL_INT_LIMIT);
+  intWorkspace_ph_ = gsl_integration_workspace_alloc(QEDFV_GSL_INT_LIMIT);
 }
 
-Coef::~Coef(void) { gsl_integration_workspace_free(intWorkspace_); }
+Coef::~Coef(void)
+{
+  gsl_integration_workspace_free(intWorkspace_);
+  gsl_integration_workspace_free(intWorkspace_r_);
+  gsl_integration_workspace_free(intWorkspace_th_);
+  gsl_integration_workspace_free(intWorkspace_ph_);
+}
 
 void Coef::setDebug(const bool debug) { debug_ = debug; }
 
@@ -74,7 +91,12 @@ double Coef::operator()(const double j, const double eta, const unsigned int nma
     }
     else
     {
-      throw std::logic_error("error: j = 3 is not implemented");
+      if (!isEqual(j, jCache_))
+      {
+        jCache_ = j;
+        intCache_ = Q3();
+      }
+      result += 4 * M_PI * (log(eta) + intCache_);
     }
   }
   else
@@ -129,7 +151,12 @@ double Coef::operator()(const double j, const DVec3 v, const double eta, const u
   }
   else
   {
-    throw std::logic_error("error: j = 3 is not implemented");
+    if (!isEqual(j, jCache_))
+    {
+      jCache_ = j;
+      intCache_ = Q3v(v) / (4 * M_PI * aVal);
+    }
+    result += 4 * M_PI * aVal * (log(eta) + intCache_);
   }
   switch (getQed())
   {
@@ -205,6 +232,43 @@ double Coef::rBar(const double j)
             intError_, time);
 
   return rbarj;
+}
+
+double Coef::Q3()
+{
+  double time, q3j;
+  double cut = QEDFV_DEFAULT_CUT;
+
+  Integrand i = [](double r) { return pow(tanh(sinh(r)), 5.) / r; };
+  time = -clockMs();
+  q3j = integrate(i, 0.0, cut) - log(cut);
+  time += clockMs();
+  dgbPrintf(isDebug(), "computed Q3, Q3= %f, error= %e, time= %f ms\n", intCache_, intError_, time);
+
+  return q3j;
+}
+
+double Coef::Q3v(const DVec3 v)
+{
+  double time, q3j;
+  double cut = QEDFV_DEFAULT_CUT;
+
+  double j = 3.0;
+  Integrand3 i = [v](double r, double th, double phi)
+  {
+    DVec3 sph = sphericalToCartesian(1.0, th, phi);
+    double vdot = 0.0;
+    for (int i = 0; i < 3; i++)
+      vdot += v[i] * sph[i];
+    return sin(th) * pow(tanh(sinh(r * pow(1.0 - vdot, 1. / 5.))), 5.) / (r * (1.0 - vdot));
+  };
+  time = -clockMs();
+  q3j = Q3v_integral(v) - 4. * M_PI * a(1., v) * log(cut);
+  time += clockMs();
+  dgbPrintf(isDebug(), "computed Q3v_j, j= %f, Q3v_j= %f, error= %e, time= %f ms\n", j, intCache_,
+            intError_, time);
+
+  return q3j;
 }
 
 Coef::Params Coef::tune(const double j, const double residual, const double eta0,
@@ -319,6 +383,68 @@ double Coef::integrate(Integrand &func)
                         &intCache_, &intError_);
 
   return intCache_;
+}
+
+double Coef::integrate(Integrand &func, const double &min, const double &max)
+{
+  gsl_function gsl_f;
+
+  double (*wrapper)(double, void *) = [](double x, void *func) -> double
+  { return (*static_cast<Integrand *>(func))(x); };
+
+  gsl_f.function = wrapper;
+  gsl_f.params = &func;
+  gsl_integration_qags(&gsl_f, min, max, 0., QEDFV_GSL_INT_PREC, QEDFV_GSL_INT_LIMIT, intWorkspace_,
+                       &intCache_, &intError_);
+
+  return intCache_;
+}
+
+double Q3v_integrand(double r, double theta, double phi, double vx, double vy, double vz)
+{
+  DVec3 sph = sphericalToCartesian(1.0, theta, phi);
+  double vdot = vx * sph[0] + vy * sph[1] + vz * sph[2];
+  return sin(theta) * pow(tanh(sinh(r * pow(1.0 - vdot, 1. / 5.))), 5.) / (r * (1.0 - vdot));
+}
+
+double Coef::Q3v_integral(const DVec3 &v)
+{
+  double params[5] = {0.0, 0.0, v[0], v[1], v[2]};
+
+  gsl_f_r.function = [](double r, void *p) -> double
+  {
+    double *params = static_cast<double *>(p);
+    return Q3v_integrand(r, params[0], params[1], params[2], params[3], params[4]);
+  };
+  gsl_f_r.params = params;
+
+  gsl_f_th.function = [](double th, void *p) -> double
+  {
+    double *params = static_cast<double *>(p);
+    params[0] = th;
+    double result, error;
+    gsl_integration_qags(&gsl_f_r, 0., QEDFV_DEFAULT_CUT, 0., QEDFV_GSL_INT_PREC,
+                         QEDFV_GSL_INT_LIMIT, intWorkspace_r_, &result, &error);
+    return result;
+  };
+  gsl_f_th.params = params;
+
+  gsl_f_ph.function = [](double ph, void *p) -> double
+  {
+    double *params = static_cast<double *>(p);
+    params[1] = ph;
+    double result, error;
+    gsl_integration_qags(&gsl_f_th, 0., M_PI, 0., QEDFV_GSL_INT_PREC, QEDFV_GSL_INT_LIMIT,
+                         intWorkspace_th_, &result, &error);
+    return result;
+  };
+  gsl_f_ph.params = params;
+
+  double result, error;
+  gsl_integration_qags(&gsl_f_ph, 0., 2. * M_PI, 0., QEDFV_GSL_INT_PREC, QEDFV_GSL_INT_LIMIT,
+                       intWorkspace_ph_, &result, &error);
+
+  return result;
 }
 
 Coef::Params Coef::tune(CoefFunc &coef, const double residual, const double eta0,

--- a/lib/qedfv/coef.hpp
+++ b/lib/qedfv/coef.hpp
@@ -35,6 +35,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #ifndef QEDFV_DEFAULT_NMAXSTEP
 #define QEDFV_DEFAULT_NMAXSTEP 5
 #endif
+#ifndef QEDFV_DEFAULT_CUT
+#define QEDFV_DEFAULT_CUT 80
+#endif
 #ifndef QEDFV_GSL_INT_LIMIT
 #define QEDFV_GSL_INT_LIMIT 10000
 #endif
@@ -77,6 +80,8 @@ public:
   double a(const double k, const DVec3 &v);
   double r(const double j);
   double rBar(const double j);
+  double Q3();
+  double Q3v(const DVec3 v);
   Params tune(const double j, const double residual = QEDFV_DEFAULT_ERROR, const double eta0 = 1.0,
               const double etaInvStep = QEDFV_DEFAULT_ETAINVSTEP, const unsigned int nmax0 = 5,
               const unsigned int nmaxStep = QEDFV_DEFAULT_NMAXSTEP);
@@ -93,6 +98,7 @@ public:
 
 private:
   typedef std::function<double(double)> Integrand;
+  typedef std::function<double(double, double, double)> Integrand3;
   typedef std::function<double(const IVec3 &n)> Summand;
   typedef std::function<double(const Params par)> CoefFunc;
 
@@ -102,6 +108,8 @@ private:
   double summand(IVec3 n, const double j, const DVec3 v, const double eta);
   double summandJ0(IVec3 n, const DVec3 v, const double eta);
   double integrate(Integrand &func);
+  double integrate(Integrand &func, const double &min, const double &max);
+  double Q3v_integral(const DVec3 &v);
   Params tune(CoefFunc &coef, const double residual, const double eta0, const double etaInvStep,
               const unsigned int nmax0, const unsigned int nmaxStep);
   double acceleratedSum(const double j, const double eta, const unsigned int nmax);
@@ -112,6 +120,10 @@ private:
   Qed qed_{Qed::L};
   double jCache_, intCache_, intError_;
   gsl_integration_workspace *intWorkspace_;
+  static gsl_integration_workspace *intWorkspace_r_;
+  static gsl_integration_workspace *intWorkspace_th_;
+  static gsl_integration_workspace *intWorkspace_ph_;
+  static gsl_function gsl_f_r, gsl_f_th, gsl_f_ph;
   static const std::map<std::string, Qed> qedMap;
 };
 

--- a/lib/qedfv/coef.hpp
+++ b/lib/qedfv/coef.hpp
@@ -78,6 +78,7 @@ public:
   double operator()(const double j, const DVec3 v, const Params par);
   double qedrTerm(const DVec3 v);
   double a(const double k, const DVec3 &v);
+  double b(const double k, const DVec3 &v);
   double r(const double j);
   double rBar(const double j);
   double Q3();


### PR DESCRIPTION
Here's a first implementation of `c3` and `c3vl` coefficients.

* the functions `Coef::Q3()` and `Chef::Q3v(const DVec3 v)` are introduced, based on eq. (A31) of [[2109.05002]](https://arxiv.org/abs/2109.05002). These functions depend on a regulator `cut` which is currently set to a fixed value `QEDFV_DEFAULT_CUT`. This works fine, but one could think about tuning this parameter as well.

* the function `Coef::Q3v_integral(const DVec3 &v)` performs a 3D integral over $\mathbf{n}$ using three nested `gsl` integrations. The current implementation works, but the `gsl` functions are set up in a slightly different way compared to the functions `integrate`, where the integrand is passed as a parameter of the gsl function. 